### PR TITLE
feat(lumberjack-admin): compatibilité WordPress 7.0

### DIFF
--- a/src/AdminProvider.php
+++ b/src/AdminProvider.php
@@ -4,6 +4,7 @@ namespace Adeliom\Lumberjack\Admin;
 
 use Adeliom\Lumberjack\Admin\Gutenberg\Block;
 use Adeliom\Lumberjack\Admin\Helpers\GutenbergBlock;
+use Adeliom\Lumberjack\Admin\Hooks\FontLibraryHooks;
 use Adeliom\Lumberjack\Admin\Hooks\RestrictionsHooks;
 use Adeliom\Lumberjack\Admin\Hooks\TemplateHooks;
 use Rareloop\Lumberjack\Config;
@@ -22,6 +23,10 @@ class AdminProvider extends ServiceProvider
         add_action('init', [TemplateHooks::class, "addBlockTemplateToPageTemplate"]);
         add_filter('use_block_editor_for_post_type', [TemplateHooks::class, "disabledGutenberg"], 10, 2);
         add_action('allowed_block_types_all', [RestrictionsHooks::class, "allowedBlock"], 10, 2);
+
+        // WordPress 7.0 : désactivation de la Font Library (menu + accès direct).
+        add_action('admin_menu', [FontLibraryHooks::class, "removeFontLibraryMenu"], 999, 0);
+        add_action('admin_init', [FontLibraryHooks::class, "blockFontLibraryAccess"], 10, 0);
 
         $gutenbergCategories = $config->get('gutenberg.categories', []);
         add_filter("block_categories_all", static function (array $categories, \WP_Block_Editor_Context $block_editor_context) use ($gutenbergCategories) {

--- a/src/Gutenberg/Block.php
+++ b/src/Gutenberg/Block.php
@@ -110,7 +110,9 @@ class Block
         'align' => false,
         'align_text' => false,
         'align_content' => false,
-        'jsx' => false
+        'jsx' => false,
+        // Désactive le champ « CSS additionnel » par bloc ajouté par WordPress 7.0.
+        'customCSS' => false,
     ];
 
     /**

--- a/src/Hooks/FontLibraryHooks.php
+++ b/src/Hooks/FontLibraryHooks.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\Lumberjack\Admin\Hooks;
+
+/**
+ * Désactive la Font Library introduite par WordPress 7.0.
+ *
+ * Compatible WP < 7 : sans Font Library, remove_submenu_page() est un no-op et
+ * $pagenow ne vaut jamais 'font-library.php', donc ces hooks sont sans effet.
+ */
+class FontLibraryHooks
+{
+    /**
+     * Retire l'entrée de menu « Polices » (Font Library, WP 7.0) sous Apparence.
+     */
+    public static function removeFontLibraryMenu(): void
+    {
+        remove_submenu_page('themes.php', 'font-library.php');
+    }
+
+    /**
+     * Bloque l'accès direct à la Font Library par URL (wp-admin/font-library.php).
+     */
+    public static function blockFontLibraryAccess(): void
+    {
+        global $pagenow;
+
+        if ('font-library.php' === $pagenow) {
+            wp_safe_redirect(admin_url());
+            exit;
+        }
+    }
+}


### PR DESCRIPTION
## Contexte

Adaptations de la librairie pour WordPress 7.0, qui introduit deux nouveautés que l'on souhaite désactiver par défaut sur les projets Adeliom.

## Changements

- **Désactivation de la Font Library** (`FontLibraryHooks`) : retrait de l'entrée de menu « Polices » sous Apparence et blocage de l'accès direct via `wp-admin/font-library.php`. Sans effet sur WP < 7.0.
- **Désactivation du « CSS additionnel » par bloc** : ajout de `'customCSS' => false` dans les `supports` par défaut des blocs (`Gutenberg\Block`).

## Notes

Les hooks et le support sont rétro-compatibles : sur une installation WordPress antérieure à la 7.0, ils sont sans effet.