### PR TITLE
feat: compatibilité WordPress 7.0 (2.x)

### DIFF
--- a/src/AdminProvider.php
+++ b/src/AdminProvider.php
@@ -4,6 +4,7 @@ namespace Adeliom\Lumberjack\Admin;
 
 use Adeliom\Lumberjack\Admin\Gutenberg\Block;
 use Adeliom\Lumberjack\Admin\Helpers\GutenbergBlock;
+use Adeliom\Lumberjack\Admin\Hooks\FontLibraryHooks;
 use Adeliom\Lumberjack\Admin\Hooks\RestrictionsHooks;
 use Adeliom\Lumberjack\Admin\Hooks\TemplateHooks;
 use Rareloop\Lumberjack\Config;
@@ -22,6 +23,10 @@ class AdminProvider extends ServiceProvider
         add_action('init', [TemplateHooks::class, "addBlockTemplateToPageTemplate"]);
         add_filter('use_block_editor_for_post_type', [TemplateHooks::class, "disabledGutenberg"], 10, 2);
         add_action('allowed_block_types_all', [RestrictionsHooks::class, "allowedBlock"], 10, 2);
+
+        // WordPress 7.0 : désactivation de la Font Library (menu + accès direct).
+        add_action('admin_menu', [FontLibraryHooks::class, "removeFontLibraryMenu"], 999, 0);
+        add_action('admin_init', [FontLibraryHooks::class, "blockFontLibraryAccess"], 10, 0);
 
         $gutenbergCategories = $config->get('gutenberg.categories', []);
         add_filter("block_categories_all", static function (array $categories, \WP_Block_Editor_Context $block_editor_context) use ($gutenbergCategories) {

--- a/src/Gutenberg/Block.php
+++ b/src/Gutenberg/Block.php
@@ -110,7 +110,9 @@ class Block
         'align' => false,
         'align_text' => false,
         'align_content' => false,
-        'jsx' => false
+        'jsx' => false,
+        // Désactive le champ « CSS additionnel » par bloc ajouté par WordPress 7.0.
+        'customCSS' => false,
     ];
 
     /**

--- a/src/Hooks/FontLibraryHooks.php
+++ b/src/Hooks/FontLibraryHooks.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\Lumberjack\Admin\Hooks;
+
+/**
+ * Désactive la Font Library introduite par WordPress 7.0.
+ *
+ * Compatible WP < 7 : sans Font Library, remove_submenu_page() est un no-op et
+ * $pagenow ne vaut jamais 'font-library.php', donc ces hooks sont sans effet.
+ */
+class FontLibraryHooks
+{
+    /**
+     * Retire l'entrée de menu « Polices » (Font Library, WP 7.0) sous Apparence.
+     */
+    public static function removeFontLibraryMenu(): void
+    {
+        remove_submenu_page('themes.php', 'font-library.php');
+    }
+
+    /**
+     * Bloque l'accès direct à la Font Library par URL (wp-admin/font-library.php).
+     */
+    public static function blockFontLibraryAccess(): void
+    {
+        global $pagenow;
+
+        if ('font-library.php' === $pagenow) {
+            wp_safe_redirect(admin_url());
+            exit;
+        }
+    }
+}


### PR DESCRIPTION
## Objectif

Porter sur **2.x** les adaptations WordPress 7.0 déjà livrées sur 1.x (tag 1.0.58), à l'identique.

## Changements

- **Font Library (WP 7.0)** — nouveau `src/Hooks/FontLibraryHooks.php` : retrait de l'entrée de menu « Polices » sous Apparence (`removeFontLibraryMenu`) + blocage de l'accès direct à `wp-admin/font-library.php` (`blockFontLibraryAccess`). Câblé dans `AdminProvider::boot()` (`admin_menu`@999, `admin_init`@10).
- **Champ « CSS additionnel » par bloc (WP 7.0)** — `'customCSS' => false` ajouté aux `supports` par défaut de `Gutenberg\Block`.

## Compatibilité

✅ Aucun fatal ni régression :
- `customCSS` : clé de `supports` inconnue sur WP < 7 → ignorée silencieusement.
- `remove_submenu_page('themes.php', 'font-library.php')` : no-op si le sous-menu n'existe pas.
- `blockFontLibraryAccess` : `$pagenow === 'font-library.php'` jamais vrai sur WP < 7.
- Code purement WP core, compatible avec le socle PHP 8.2 de 2.x.

Fichiers identiques (byte-à-byte) à ceux livrés sur 1.x.